### PR TITLE
[backup PR #905] Update net-ssh

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "excon", "~> 0.44"
   gem.add_dependency "unf", "0.1.3" # for fog/AWS
   gem.add_dependency "dropbox-sdk", "1.6.5"
-  gem.add_dependency "net-ssh", "3.2.0"
+  gem.add_dependency "net-ssh", "4.2.0"
   gem.add_dependency "net-scp", "1.2.1"
   gem.add_dependency "net-sftp", "2.1.2"
   gem.add_dependency "mail", "~> 2.6", ">= 2.6.6"


### PR DESCRIPTION
Version 4.x has support for Ruby 2.4 (means it resolve some
deprecation warnings).