### PR TITLE
Fix bundler version in Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ To report a bug, use the [GitHub issue tracker](https://github.com/backupii/back
 check the Open issues, and create a new issue if you do not see a report that matches the bug that
 you have found.
 
-Backupii is used with many different systems and configurations, so the first step for us to solve a
+BackupII is used with many different systems and configurations, so the first step for us to solve a
 problem is knowing how to reproduce it. You can help us solve your issue by including the versions
-of Ruby, Backupii and the operating system on the computer that you used.
+of Ruby, BackupII and the operating system on the computer that you used.
 
 To submit a bug fix, please [create a Pull Request](https://github.com/backupii/backupii/compare).
 Always develop changes against the `master` branch. Read the Pull Requests section below for more
@@ -49,3 +49,20 @@ In addition to contributing code, you can help to triage issues. This can includ
 reports or asking for vital information, such as version numbers or reproduction instructions. If
 you would like to start triaging issues, one easy way to get started is to [subscribe to backupii on
 CodeTriage](https://www.codetriage.com/backupii/backupii).
+
+## Getting started
+
+BackupII is a Ruby app that is unit and integration tested with Rspec and linted with Rubocop:
+
+```bash
+bundle
+bundle exec rubocop
+bundle exec rspec spec
+bundle exec rspec integration
+```
+
+There is also a [Dockerfile](Dockerfile) and respective Rake tasks to run all the tests in Docker:
+
+```bash
+bundle exec rake docker:prepare docker:spec docker:integration
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.3
+FROM ruby:2.6.3
 
 ## 1. Image metadata ##
  LABEL maintainer="stuart@stuartellis.name" \
@@ -19,3 +19,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends $APP_DEPS
 
 ENV APP_HOME /usr/src/backup
 WORKDIR $APP_HOME
+
+# Update bundler to version 2
+RUN gem install bundler

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ protocols/services, syncers, compressors, encryptors and notifiers
 which you can mix and match. It was built with modularity,
 extensibility and simplicity in mind.
 
-[Installation][] &middot; [Release Notes][] &middot; [Documentation][] &middot; [Issues][]
+[Installation][] &middot; [Release Notes][] &middot; [Documentation][] &middot; [Issues][] &middot; [Contributing and getting started][]
 
 ## Project Status: Forking just started ##
 
@@ -32,5 +32,6 @@ Released under the **MIT** [LICENSE](LICENSE).
 [Release Notes]: http://backupii.github.io/backupii/v4/release-notes
 [Documentation]: http://backupii.github.io/backupii/v4
 [Issues]: https://github.com/backupii/backupii/issues
+[Contributing and getting started]: CONTRIBUTING.md
 [Maintainers wanted]: https://github.com/backupii/backupii/issues/1
 [Michael van Rooijen]: http://github.com/mrrooijen


### PR DESCRIPTION
The Gemfile.lock requires bundler version 2 but the current Dockerfile setup only includes bundler version 1.x. This PR introduces the Ruby version 2.6.3 in Docker and bundler version 2. In the Ruby Docker image with version 2.4.3 the bundler update did not work.

When I wanted to check out this project I wasn't aware that I could run the tests in Docker. So I thought a short note on this would be helpful for others who want to check out this project.